### PR TITLE
fix/date-validation

### DIFF
--- a/php/component/field/class-fieldabstract.php
+++ b/php/component/field/class-fieldabstract.php
@@ -356,8 +356,7 @@ abstract class FieldAbstract {
 		$allowed = true;
 		// Check id the field is required first.
 		if ( true === $this->args['required'] ) {
-			// Is null, set allowed to false if required.
-			if ( is_null( $value ) ) {
+			if ( empty( $value ) ) {
 				$allowed = false;
 			}
 			// Check if there's conditional logic.

--- a/php/component/field/class-fieldabstract.php
+++ b/php/component/field/class-fieldabstract.php
@@ -142,7 +142,7 @@ abstract class FieldAbstract {
 		$messages = array(
 			'invalid_value' => array(
 				'type'    => 'error',
-				'message' => __( 'Invalid Value', 'formation' ),
+				'message' => sprintf( __( '%s is invalid', 'formation' ), $this->get_input_label() ),
 			),
 			'required'      => array(
 				'type'    => 'error',

--- a/php/component/field/class-fieldabstract.php
+++ b/php/component/field/class-fieldabstract.php
@@ -214,7 +214,8 @@ abstract class FieldAbstract {
 		$value          = apply_filters( 'formation_field_set_value_' . $this->type . '_' . $this->args['slug'], $value, $this );
 		$proposed_value = $this->validate_value( $value );
 		if ( is_wp_error( $proposed_value ) ) {
-			$this->args['value'] = $proposed_value->get_error_message(); // Set to the error since it may be from the filters.
+			// Set to the original value so users will know what input value is causing validation to fail.
+			$this->args['value'] = $value;
 		} else {
 			/**
 			 * Set to the proposed value regardless of validation to allow the user to change or replace the value.
@@ -482,17 +483,13 @@ abstract class FieldAbstract {
 	 */
 	public function get_input_attributes() {
 
-		$value = $this->args['value'];
-		if ( ! empty( $value ) && 'date' === $this->args['type'] ) {
-			$value = Utils::date( 'Y-m-d', Utils::gmstrtotime( $value ) );
-		}
 		$attributes = array(
 			'type'        => $this->args['type'],
 			'name'        => $this->get_input_name(),
 			'id'          => $this->get_id(),
 			'placeholder' => $this->args['placeholder'],
 			'required'    => $this->args['required'],
-			'value'       => $value,
+			'value'       => $this->args['value'],
 			'data-field'  => $this->type,
 			'data-slug'   => $this->args['slug'],
 			'class'       => array(


### PR DESCRIPTION
On Safari, when the Date input value is invalid, the Form will crash upon submission.

The `set_value()` method validates and sets the `$this->args['value']` to the original input value IF it is an error. However the `get_input_attributes()` runs after `set_value()` and sets the Date Input value back to a `WP_Error` object. This results in a fatal error when the `WP_Error` object is passed to `esc_attr()` in the static `build_attributes()` method.

There doesn't seem to be a need for `get_input_attributes()` to do any setting of values; hence we only need to rely on `set_value()`. The original value will be used to mimic typical Form behavior of retaining the value the User entered when validation fails.

This PR handles DOB error validation gracefully by displaying the error message at the top as well as below the input field.
